### PR TITLE
Two Rails shortcuts that are in the docs but weren't in the keymap

### DIFF
--- a/IntelliJKeymap.xml
+++ b/IntelliJKeymap.xml
@@ -19,6 +19,10 @@
     <keyboard-shortcut first-keystroke="control meta alt LEFT" />
     <keyboard-shortcut first-keystroke="control meta alt RIGHT" />
   </action>
+  <action id="QuickList.Ruby/Rails">
+    <keyboard-shortcut first-keystroke="meta alt R" />
+  </action>
+  <action id="Resume" />
   <action id="SplitHorizontally">
     <keyboard-shortcut first-keystroke="control meta alt DOWN" />
   </action>


### PR DESCRIPTION
option + R - run Rake task
command + option + R - Ruby/Rails quick list
