### PR TITLE
Next and previous bookmark

### DIFF
--- a/IntelliJKeymap.xml
+++ b/IntelliJKeymap.xml
@@ -18,6 +18,12 @@
     <keyboard-shortcut first-keystroke="shift meta O" />
     <keyboard-shortcut first-keystroke="shift meta N" />
   </action>
+  <action id="GotoNextBookmark">
+    <keyboard-shortcut first-keystroke="meta alt F3" />
+  </action>
+  <action id="GotoPreviousBookmark">
+    <keyboard-shortcut first-keystroke="shift meta alt F3" />
+  </action>
   <action id="MoveEditorToOppositeTabGroup">
     <keyboard-shortcut first-keystroke="control meta alt LEFT" />
     <keyboard-shortcut first-keystroke="control meta alt RIGHT" />


### PR DESCRIPTION
These two shortcuts are not in the default OS X 10.5+ keymap.
F3 was chosen because it's consistent with the other OS X 10.5+
bookmark shortcuts.
