### PR TITLE
Resume program shortcut

### DIFF
--- a/IntelliJKeymap.xml
+++ b/IntelliJKeymap.xml
@@ -31,7 +31,9 @@
   <action id="QuickList.Ruby/Rails">
     <keyboard-shortcut first-keystroke="meta alt R" />
   </action>
-  <action id="Resume" />
+  <action id="Resume">
+    <keyboard-shortcut first-keystroke="F9" />
+  </action>
   <action id="SplitHorizontally">
     <keyboard-shortcut first-keystroke="control meta alt DOWN" />
   </action>


### PR DESCRIPTION
In the "Mac OS X 10.5+" keymap, "Resume program" is mapped to
command + option + R, even though it's listed as F9 on
http://www.jetbrains.com/ruby/docs/RubyMine_ReferenceCard_Mac.pdf.
