### PR TITLE
Remove cmd-shift-N

### DIFF
--- a/IntelliJKeymap.xml
+++ b/IntelliJKeymap.xml
@@ -16,7 +16,6 @@
   </action>
   <action id="GotoFile">
     <keyboard-shortcut first-keystroke="shift meta O" />
-    <keyboard-shortcut first-keystroke="shift meta N" />
   </action>
   <action id="GotoNextBookmark">
     <keyboard-shortcut first-keystroke="meta alt F3" />


### PR DESCRIPTION
I removed cmd-shift-N from the key mappings. We should be using cmd-shift-O, which is the same as the default RubyMine key mapping.
