### PR TITLE
Remove legacy Pivotal keymap shortcuts

### DIFF
--- a/IntelliJKeymap.xml
+++ b/IntelliJKeymap.xml
@@ -6,18 +6,6 @@
   <action id="CloseAllEditorsButActive">
     <keyboard-shortcut first-keystroke="shift meta W" />
   </action>
-  <action id="EditorSelectWord">
-    <keyboard-shortcut first-keystroke="alt UP" />
-    <keyboard-shortcut first-keystroke="control W" />
-  </action>
-  <action id="EditorUnSelectWord">
-    <keyboard-shortcut first-keystroke="alt DOWN" />
-    <keyboard-shortcut first-keystroke="shift control W" />
-  </action>
-  <action id="GotoFile">
-    <keyboard-shortcut first-keystroke="shift meta O" />
-    <keyboard-shortcut first-keystroke="shift meta N" />
-  </action>
   <action id="GotoNextBookmark">
     <keyboard-shortcut first-keystroke="meta alt F3" />
   </action>


### PR DESCRIPTION
Supporting the legacy Pivotal keymap shortcuts has upset developers who are looking to standardize our keymap. They were unaware that these legacy Pivotal keymap shortcuts were not part of the OS X 10.5+ keymap.
