### PR TITLE
Vim-like shortcuts

### DIFF
--- a/IntelliJKeymap.xml
+++ b/IntelliJKeymap.xml
@@ -6,6 +6,9 @@
   <action id="CloseAllEditorsButActive">
     <keyboard-shortcut first-keystroke="shift meta W" />
   </action>
+  <action id="EditorScrollToCenter">
+    <keyboard-shortcut first-keystroke="shift meta M" />
+  </action>
   <action id="EditorSelectWord">
     <keyboard-shortcut first-keystroke="alt UP" />
     <keyboard-shortcut first-keystroke="control W" />


### PR DESCRIPTION
This is for the addition of two useful shortcuts found in Vim:

Find word at caret (*)
Scroll to center (zz)

No default shortcuts were overridden.
